### PR TITLE
Implements `os/build` integration alongside many improvements

### DIFF
--- a/data/models12.sample.go
+++ b/data/models12.sample.go
@@ -6,7 +6,7 @@ import (
 )
 
 func welcome(buf *Buffer) {
-	if b, exrr := buf.ReadByte(); exrr != nil {
+	if b, err := buf.ReadByte(); err != nil {
 		fmt.Println(b)
 	}
 }

--- a/definitions.go
+++ b/definitions.go
@@ -265,8 +265,23 @@ func (p *Package) StructByName(name string) *Struct {
 	return nil
 }
 
+// EnsureRefType will try to get the RefType from the list by the name param. If
+// the RefType exists, it will return the reference with true (second return).
+// If it is does not exists in the list, the function will create a new type and
+// return it with false (second return).
+func (p *Package) EnsureRefType(name string) (RefType, bool) {
+	refType, ok := p.RefTypeByName(name)
+	if ok {
+		return refType, true
+	}
+	refType = NewRefType(name, p, nil)
+	p.AddRefType(refType)
+	return refType, false
+}
+
 // RefTypeByName find RefType by name.
 func (p *Package) RefTypeByName(name string) (RefType, bool) {
+	// TODO(jota): Create a map for improve the performance of this.
 	for _, pp := range p.RefType {
 		if name == pp.Name() {
 			return pp, true

--- a/definitions.go
+++ b/definitions.go
@@ -52,11 +52,11 @@ type Interface struct {
 type MethodArgument struct {
 	Name string
 	Type RefType
+	Doc  Doc
 }
 
 type MethodDescriptor struct {
-	pkg       *Package
-	name      string
+	baseType
 	Doc       Doc
 	Recv      []MethodArgument
 	Arguments []MethodArgument
@@ -92,6 +92,10 @@ func NewPackage(buildPackage *build.Package) *Package {
 		Name:       buildPackage.Name,
 		ImportPath: buildPackage.ImportPath,
 		RealPath:   buildPackage.Dir,
+		RefType: []RefType{
+			NullRefType,
+			InterfaceRefType,
+		},
 	}
 }
 
@@ -107,6 +111,15 @@ type BaseRefType struct {
 	pkg  *Package
 	t    Type
 }
+
+var (
+	NullRefType = &BaseRefType{
+		name: "nil",
+	}
+	InterfaceRefType = &BaseRefType{
+		name: "interface",
+	}
+)
 
 func NewRefType(name string, pkg *Package, t Type) RefType {
 	return &BaseRefType{
@@ -198,6 +211,7 @@ type TagParam struct {
 type Variable struct {
 	Name    string
 	RefType RefType
+	Doc     Doc
 }
 
 // FormatComment is simple method to remove // or /* */ of comment
@@ -235,8 +249,7 @@ func (i *Interface) Name() string {
 // NewMethodDescriptor return the pointer of new MethodDescriptor
 func NewMethodDescriptor(pkg *Package, name string) *MethodDescriptor {
 	return &MethodDescriptor{
-		pkg:  pkg,
-		name: name,
+		baseType: *NewBaseType(pkg, name),
 	}
 }
 
@@ -313,9 +326,9 @@ func (p *Package) VariableByName(name string) (vrle *Variable) {
 	return nil
 }
 
-func (p *Package) AppendVariable(vrle *Variable) (v *Variable) {
-	p.Variables = append(p.Variables, vrle)
-	return vrle
+func (p *Package) AppendVariable(variable *Variable) *Variable {
+	p.Variables = append(p.Variables, variable)
+	return variable
 }
 
 // NewStruct return new pointer Struct

--- a/definitions.go
+++ b/definitions.go
@@ -1,12 +1,13 @@
 package myasthurts
 
 import (
+	"fmt"
 	"go/build"
 	"regexp"
 	"strings"
 )
 
-type constant struct {
+type Constant struct {
 	Name string
 	Type Type
 }
@@ -17,8 +18,13 @@ type Doc struct {
 
 // EnvConfig is a Struct to set config in Environment
 type EnvConfig struct {
-	DevMode bool
-	ASTI    bool
+	DevMode    bool
+	ASTI       bool
+	CurrentDir string
+}
+
+func (ec EnvConfig) CWD() string {
+	return ec.CurrentDir
 }
 
 // Field is utilized in Struct type in the present moment.
@@ -35,7 +41,7 @@ type File struct {
 	FileName   string
 	Doc        Doc
 	Variables  []*Variable
-	Constants  []*constant
+	Constants  []*Constant
 	Structs    []*Struct
 	Interfaces []*Interface
 	Files      []*File
@@ -76,11 +82,13 @@ type Package struct {
 	explored    bool
 	Doc         Doc
 	Variables   []*Variable
-	Constants   []*constant
+	Constants   []*Constant
 	Methods     []*MethodDescriptor
+	methodMap   map[string]*MethodDescriptor
 	Structs     []*Struct
 	Interfaces  []*Interface
 	RefType     []RefType
+	refTypeMap  map[string]RefType
 	Types       []Type
 	Files       []*File
 	Parent      *Package
@@ -92,10 +100,20 @@ func NewPackage(buildPackage *build.Package) *Package {
 		Name:       buildPackage.Name,
 		ImportPath: buildPackage.ImportPath,
 		RealPath:   buildPackage.Dir,
+		Constants:  make([]*Constant, 0),
+		Methods:    make([]*MethodDescriptor, 0),
+		Variables:  make([]*Variable, 0),
+		methodMap:  make(map[string]*MethodDescriptor),
+		Structs:    make([]*Struct, 0),
+		Interfaces: make([]*Interface, 0),
 		RefType: []RefType{
 			NullRefType,
 			InterfaceRefType,
 		},
+		refTypeMap:  make(map[string]RefType),
+		Types:       make([]Type, 0),
+		Files:       make([]*File, 0),
+		Subpackages: make([]*Package, 0),
 	}
 }
 
@@ -146,6 +164,163 @@ func (rt *BaseRefType) AppendType(tp Type) {
 	rt.t = tp
 }
 
+type StarRefType struct {
+	RefType
+}
+
+func NewStarRefType(refType RefType) *StarRefType {
+	return &StarRefType{
+		RefType: refType,
+	}
+}
+
+func (refType *StarRefType) Name() string {
+	return refType.RefType.Name()
+}
+
+func (refType *StarRefType) Pkg() *Package {
+	return refType.RefType.Pkg()
+}
+
+func (refType *StarRefType) Type() Type {
+	return refType.RefType.Type()
+}
+
+func (refType *StarRefType) AppendType(tp Type) {
+	refType.RefType.AppendType(tp)
+}
+
+type ArrayRefType struct {
+	RefType
+}
+
+func NewArrayRefType(refType RefType) *ArrayRefType {
+	return &ArrayRefType{
+		RefType: refType,
+	}
+}
+
+func (refType *ArrayRefType) Name() string {
+	return refType.RefType.Name()
+}
+
+func (refType *ArrayRefType) Pkg() *Package {
+	return refType.RefType.Pkg()
+}
+
+func (refType *ArrayRefType) Type() Type {
+	return refType.RefType.Type()
+}
+
+func (refType *ArrayRefType) AppendType(tp Type) {
+	refType.RefType.AppendType(tp)
+}
+
+type ChanRefType struct {
+	RefType
+}
+
+func NewChanRefType(refType RefType) *ChanRefType {
+	return &ChanRefType{
+		RefType: refType,
+	}
+}
+
+func (refType *ChanRefType) Name() string {
+	return refType.RefType.Name()
+}
+
+func (refType *ChanRefType) Pkg() *Package {
+	return refType.RefType.Pkg()
+}
+
+func (refType *ChanRefType) Type() Type {
+	return refType.RefType.Type()
+}
+
+func (refType *ChanRefType) AppendType(tp Type) {
+	refType.RefType.AppendType(tp)
+}
+
+type EllipsisRefType struct {
+	RefType
+}
+
+func NewEllipsisRefType(refType RefType) *EllipsisRefType {
+	return &EllipsisRefType{
+		RefType: refType,
+	}
+}
+
+func (refType *EllipsisRefType) Name() string {
+	return refType.RefType.Name()
+}
+
+func (refType *EllipsisRefType) Pkg() *Package {
+	return refType.RefType.Pkg()
+}
+
+func (refType *EllipsisRefType) Type() Type {
+	return refType.RefType.Type()
+}
+
+func (refType *EllipsisRefType) AppendType(tp Type) {
+	refType.RefType.AppendType(tp)
+}
+
+type MapType struct {
+	pkg   *Package
+	Key   RefType
+	Value RefType
+}
+
+func NewMap(pkg *Package, key RefType, value RefType) *MapType {
+	return &MapType{
+		Key:   key,
+		Value: value,
+	}
+}
+
+func (mt *MapType) Package() *Package {
+	return mt.pkg
+}
+
+func (mt *MapType) Name() string {
+	return fmt.Sprintf("map[%s]%s", mt.Key.Name(), mt.Value.Name())
+}
+
+func (mt *MapType) Methods() []*TypeMethod {
+	return nil
+}
+
+func (mt *MapType) AddMethod(method *TypeMethod) {}
+
+type Ellipsis struct {
+	pkg *Package
+	Elt RefType
+}
+
+func NewEllipsis(pkg *Package, elt RefType) *Ellipsis {
+	return &Ellipsis{
+		pkg: pkg,
+		Elt: elt,
+	}
+}
+
+func (el *Ellipsis) Package() *Package {
+	return el.pkg
+}
+
+func (el *Ellipsis) Name() string {
+	return ""
+}
+
+func (el *Ellipsis) Methods() []*TypeMethod {
+	return nil
+}
+
+func (el *Ellipsis) AddMethod(method *TypeMethod) {}
+
 type Type interface {
 	Package() *Package
 	Name() string
@@ -182,7 +357,6 @@ func (t *baseType) Methods() []*TypeMethod {
 
 func (t *baseType) AddMethod(method *TypeMethod) {
 	t.methods = append(t.methods, method)
-	// TODO(jota): Add map to improve future use.
 }
 
 type Struct struct {
@@ -294,17 +468,15 @@ func (p *Package) EnsureRefType(name string) (RefType, bool) {
 
 // RefTypeByName find RefType by name.
 func (p *Package) RefTypeByName(name string) (RefType, bool) {
-	// TODO(jota): Create a map for improve the performance of this.
-	for _, pp := range p.RefType {
-		if name == pp.Name() {
-			return pp, true
-		}
-	}
-	return nil, false
+	refType, ok := p.refTypeMap[name]
+	return refType, ok
 }
 
 func (p *Package) AddRefType(ref RefType) {
-	p.RefType = append(p.RefType, ref)
+	if ref.Name() != "" {
+		p.RefType = append(p.RefType, ref)
+		p.refTypeMap[ref.Name()] = ref
+	}
 }
 
 // AppendRefType add new RefType in Package.
@@ -313,8 +485,18 @@ func (p *Package) AppendRefType(name string) (ref RefType) {
 		pkg:  p,
 		name: name,
 	}
-	p.RefType = append(p.RefType, ref)
+	p.AddRefType(ref)
 	return ref
+}
+
+func (p *Package) AppendMethod(method *MethodDescriptor) {
+	p.Methods = append(p.Methods, method)
+	//p.methodMap[method.Name()] = method
+}
+
+func (p *Package) MethodByName(name string) (*MethodDescriptor, bool) {
+	m, ok := p.methodMap[name]
+	return m, ok
 }
 
 func (p *Package) VariableByName(name string) (vrle *Variable) {

--- a/environment.go
+++ b/environment.go
@@ -50,7 +50,7 @@ func (ctx *parseFileContext) PackageByImportAlias(name string) (*Package, bool) 
 
 // GetRefType will return a type defined on the context or in the dot imported
 // libraries. If no file exists, it will return an `ErrTypeNotFound`.
-func (ctx *parseFileContext) GetRefType(name string) (*RefType, error) {
+func (ctx *parseFileContext) GetRefType(name string) (RefType, error) {
 	// First, it tries to find the type on its own package.
 	if t, ok := ctx.Package.RefTypeByName(name); ok {
 		return t, nil

--- a/environment.go
+++ b/environment.go
@@ -35,12 +35,6 @@ type parseFileContext struct {
 	Package               *Package
 	dotImports            []*Package
 	packageImportAliasMap map[string]*Package
-	packageImportPathMap  map[string]*Package
-}
-
-func (ctx *parseFileContext) PackageByImportPath(name string) (*Package, bool) {
-	pkg, ok := ctx.packageImportPathMap[name]
-	return pkg, ok
 }
 
 func (ctx *parseFileContext) PackageByImportAlias(name string) (*Package, bool) {
@@ -50,21 +44,21 @@ func (ctx *parseFileContext) PackageByImportAlias(name string) (*Package, bool) 
 
 // GetRefType will return a type defined on the context or in the dot imported
 // libraries. If no file exists, it will return an `ErrTypeNotFound`.
-func (ctx *parseFileContext) GetRefType(name string) (RefType, error) {
+func (ctx *parseFileContext) GetRefType(name string) (RefType, bool) {
 	// First, it tries to find the type on its own package.
 	if t, ok := ctx.Package.RefTypeByName(name); ok {
-		return t, nil
+		return t, true
 	}
 
 	// Now, it tries to find into the dot imported libraries.
 	for _, pkg := range ctx.dotImports {
 		if t, ok := pkg.RefTypeByName(name); ok {
-			return t, nil
+			return t, true
 		}
 	}
 
 	// Givin' up, never so easy...
-	return nil, ErrTypeNotFound
+	return nil, false
 }
 
 type environment struct {
@@ -190,7 +184,6 @@ func (env *environment) parseFile(pkgCtx *parsePackageContext, filePath string) 
 			env.BuiltIn,
 		},
 		packageImportAliasMap: make(map[string]*Package),
-		packageImportPathMap:  make(map[string]*Package),
 	}
 
 	// Prints the AST, if configured.

--- a/environment.go
+++ b/environment.go
@@ -72,11 +72,9 @@ type environment struct {
 	// packageMap stores the *Packages reference by its import name.
 	packageMap map[string]*Package
 
-	// TODO(jota): What does it do?
 	Config EnvConfig
 }
 
-// NewEnvironment is the method allow start parse in file.
 func NewEnvironment() (*environment, error) {
 	env := &environment{
 		packages:     make([]*Package, 0, 5),
@@ -88,6 +86,21 @@ func NewEnvironment() (*environment, error) {
 		return nil, err
 	}
 	return env, nil
+}
+
+func (env *environment) Import(importPathPkg string) (*build.Package, error) {
+	d := "."
+	if env.Config.CurrentDir != "" {
+		d = env.Config.CurrentDir
+	}
+	buildPkg, err := env.BuildContext.Import(importPathPkg, d, build.ImportComment)
+	if err != nil {
+		return nil, err
+	}
+	if err != nil {
+		return nil, err
+	}
+	return buildPkg, nil
 }
 
 // PackageByImportPath find Package by name in Environment.
@@ -201,7 +214,6 @@ func (env *environment) parseFile(pkgCtx *parsePackageContext, filePath string) 
 
 	decls := file.Decls
 	for _, d := range decls {
-		// TODO(jota): We must have a default case here. Shall it return an error?
 		switch c := d.(type) {
 		case *ast.GenDecl:
 			err = parseGenDecl(fileCtx, c)
@@ -213,7 +225,11 @@ func (env *environment) parseFile(pkgCtx *parsePackageContext, filePath string) 
 			if err != nil {
 				return err
 			}
+
+		default:
+			return errors.New("Decl not found")
 		}
+
 	}
 	return nil
 }

--- a/environment.go
+++ b/environment.go
@@ -174,15 +174,18 @@ func (env *environment) parseFile(pkgCtx *parsePackageContext, filePath string) 
 		return err
 	}
 
+	dotImports := make([]*Package, 0, 1)
+	if env.BuiltIn != nil {
+		// Adds the built in as a default dot imported package. If it is defined.
+		dotImports = append(dotImports, env.BuiltIn)
+	} // If it is not defined, it means we are parsing the builtin package.
+
 	// Create the context of the file parse.
 	fileCtx := &parseFileContext{
-		File:    file,
-		Env:     env,
-		Package: pkgCtx.Package,
-		dotImports: []*Package{
-			// Adds the built in as a default dot imported package.
-			env.BuiltIn,
-		},
+		File:                  file,
+		Env:                   env,
+		Package:               pkgCtx.Package,
+		dotImports:            dotImports,
 		packageImportAliasMap: make(map[string]*Package),
 	}
 

--- a/environment.go
+++ b/environment.go
@@ -1,0 +1,223 @@
+package myasthurts
+
+import (
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/build"
+	"go/parser"
+	"go/token"
+	"os"
+	"path"
+)
+
+// parsePackageContext keeps all information needed for parsing a package.
+type parsePackageContext struct {
+	// BuildPackage holds the build information about the package.
+	BuildPackage *build.Package
+
+	// Package is what is being parsed. It will keep all information for what is
+	// being parsed.
+	Package *Package
+}
+
+func NewPackageContext(pkg *Package, buildPackage *build.Package) *parsePackageContext {
+	return &parsePackageContext{
+		BuildPackage: buildPackage,
+		Package:      pkg,
+	}
+}
+
+// parseFileContext will keep all information needed for parsing a single file.
+type parseFileContext struct {
+	File                  *ast.File
+	Env                   *environment
+	Package               *Package
+	dotImports            []*Package
+	packageImportAliasMap map[string]*Package
+	packageImportPathMap  map[string]*Package
+}
+
+func (ctx *parseFileContext) PackageByImportPath(name string) (*Package, bool) {
+	pkg, ok := ctx.packageImportPathMap[name]
+	return pkg, ok
+}
+
+func (ctx *parseFileContext) PackageByImportAlias(name string) (*Package, bool) {
+	pkg, ok := ctx.packageImportAliasMap[name]
+	return pkg, ok
+}
+
+// GetRefType will return a type defined on the context or in the dot imported
+// libraries. If no file exists, it will return an `ErrTypeNotFound`.
+func (ctx *parseFileContext) GetRefType(name string) (*RefType, error) {
+	// First, it tries to find the type on its own package.
+	if t, ok := ctx.Package.RefTypeByName(name); ok {
+		return t, nil
+	}
+
+	// Now, it tries to find into the dot imported libraries.
+	for _, pkg := range ctx.dotImports {
+		if t, ok := pkg.RefTypeByName(name); ok {
+			return t, nil
+		}
+	}
+
+	// Givin' up, never so easy...
+	return nil, ErrTypeNotFound
+}
+
+type environment struct {
+	BuildContext build.Context
+	// BuiltIn is the builtin package reference, already explored.
+	BuiltIn *Package
+
+	// packages is the list of packages inside of this environment.
+	packages []*Package
+
+	// packageMap stores the *Packages reference by its import name.
+	packageMap map[string]*Package
+
+	// TODO(jota): What does it do?
+	Config EnvConfig
+}
+
+// NewEnvironment is the method allow start parse in file.
+func NewEnvironment() (*environment, error) {
+	env := &environment{
+		packages:     make([]*Package, 0, 5),
+		packageMap:   make(map[string]*Package, 5),
+		BuildContext: build.Default,
+	}
+
+	if err := env.makeEnv(); err != nil {
+		return nil, err
+	}
+	return env, nil
+}
+
+// PackageByImportPath find Package by name in Environment.
+func (env *environment) PackageByImportPath(importPath string) (*Package, bool) {
+	pkg, ok := env.packageMap[importPath]
+	return pkg, ok
+}
+
+// AppendPackage add new Package in Environment.
+func (env *environment) AppendPackage(pkg *Package) {
+	env.packages = append(env.packages, pkg)
+	env.packageMap[pkg.ImportPath] = pkg
+}
+
+// parsePackage will list all files for a package and
+func (env *environment) parsePackage(pkgCtx *parsePackageContext) error {
+	for _, file := range pkgCtx.BuildPackage.GoFiles {
+		filePath := path.Join(pkgCtx.Package.RealPath, file)
+		if err := env.parseFile(pkgCtx, filePath); err != nil {
+			return err
+		}
+	}
+	pkgCtx.Package.explored = true
+	return nil
+}
+
+// Parse checks if the parse was already done, if not, it parses the package.
+func (env *environment) Parse(packageName string) (*Package, error) {
+	p, ok := env.packageMap[packageName]
+	if ok && p.explored { // If the package exists in the environment and it was explored.
+		return p, nil // just return it, no need to do anything.
+	}
+
+	ctx := &env.BuildContext
+
+	// Find the path of the package.
+	buildPkg, err := ctx.Import(packageName, ".", build.ImportComment)
+	if err != nil {
+		return nil, err
+	}
+
+	newPkg := p
+	if newPkg == nil {
+		newPkg = NewPackage(buildPkg)
+	}
+
+	pkgCtx := NewPackageContext(newPkg, buildPkg)
+	if err = env.parsePackage(pkgCtx); err != nil {
+		return nil, err
+	}
+
+	if p == nil { // If it was not defined before
+		env.AppendPackage(pkgCtx.Package) // define it now
+	}
+
+	return pkgCtx.Package, nil
+}
+
+func (env *environment) gorootSourceDir() (rtn string, exrr error) {
+	if rtn = os.Getenv("GOROOT"); rtn == "" {
+		return "", errors.New("GOROOT environment variable not found or is empty")
+	}
+	return fmt.Sprintf("%s/src", rtn), nil
+}
+
+func (env *environment) makeEnv() error {
+	pkg, err := env.Parse("builtin")
+	if err != nil {
+		return err
+	}
+	env.BuiltIn = pkg
+	return nil
+}
+
+func (env *environment) parseFile(pkgCtx *parsePackageContext, filePath string) error {
+	var (
+		file *ast.File
+		fset *token.FileSet
+		err  error
+	)
+
+	fset = token.NewFileSet()
+	if file, err = parser.ParseFile(fset, filePath, nil, parser.ParseComments); err != nil {
+		return err
+	}
+
+	// Create the context of the file parse.
+	fileCtx := &parseFileContext{
+		File:    file,
+		Env:     env,
+		Package: pkgCtx.Package,
+		dotImports: []*Package{
+			// Adds the built in as a default dot imported package.
+			env.BuiltIn,
+		},
+		packageImportAliasMap: make(map[string]*Package),
+		packageImportPathMap:  make(map[string]*Package),
+	}
+
+	// Prints the AST, if configured.
+	if env.Config.DevMode && env.Config.ASTI {
+		ast.Print(fset, file)
+	}
+
+	err = parseFileName(fileCtx)
+	if err != nil {
+		return err
+	}
+
+	decls := file.Decls
+	for _, d := range decls {
+		// TODO(jota): We must have a default case here. Shall it return an error?
+		switch c := d.(type) {
+		case *ast.GenDecl:
+			err = parseGenDecl(fileCtx, c)
+			if err != nil {
+				return err
+			}
+		case *ast.FuncDecl:
+			err = parseFuncDecl(fileCtx, c)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/errors.go
+++ b/errors.go
@@ -3,6 +3,9 @@ package myasthurts
 import "errors"
 
 var (
-	ErrTypeNotFound    = errors.New("type not found")
-	ErrBuiltInNotFound = errors.New("builtin package not found")
+	ErrTypeNotFound             = errors.New("type not found")
+	ErrBuiltInNotFound          = errors.New("builtin package not found")
+	ErrPackageAliasNotFound     = errors.New("package alias not found")
+	ErrUnexpectedSelector       = errors.New("unexpected selector identifier")
+	ErrUnexpectedExpressionType = errors.New("unexpected expression type")
 )

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,8 @@
+package myasthurts
+
+import "errors"
+
+var (
+	ErrTypeNotFound    = errors.New("type not found")
+	ErrBuiltInNotFound = errors.New("builtin package not found")
+)

--- a/experiment_test.go
+++ b/experiment_test.go
@@ -98,11 +98,11 @@ var _ = Describe("My AST Hurts - Parse simples files with tags and func from str
 			Expect(pkg.Structs[0].Fields[0].RefType).ToNot(Equal(BeNil()))
 			Expect(pkg.Structs[0].Fields[1].RefType).ToNot(Equal(BeNil()))
 
-			Expect(pkg.Structs[0].Fields[0].RefType.Name).To(Equal("int64"))
-			Expect(pkg.Structs[0].Fields[1].RefType.Name).To(Equal("string"))
+			Expect(pkg.Structs[0].Fields[0].RefType.Name()).To(Equal("int64"))
+			Expect(pkg.Structs[0].Fields[1].RefType.Name()).To(Equal("string"))
 
-			Expect(pkg.Structs[0].Fields[0].RefType.Type).To(BeNil())
-			Expect(pkg.Structs[0].Fields[1].RefType.Type).To(BeNil())
+			Expect(pkg.Structs[0].Fields[0].RefType.Type()).To(BeNil())
+			Expect(pkg.Structs[0].Fields[1].RefType.Type()).To(BeNil())
 
 			Expect(pkg.Structs[1].Fields[0].Name).To(Equal("ID"))
 			Expect(pkg.Structs[1].Fields[1].Name).To(Equal("Address"))
@@ -112,15 +112,15 @@ var _ = Describe("My AST Hurts - Parse simples files with tags and func from str
 			Expect(pkg.Structs[1].Fields[1].RefType).ToNot(BeNil())
 			Expect(pkg.Structs[1].Fields[2].RefType).ToNot(BeNil())
 
-			Expect(pkg.Structs[1].Fields[0].RefType.Name).To(Equal("int64"))
-			Expect(pkg.Structs[1].Fields[1].RefType.Name).To(Equal("string"))
-			Expect(pkg.Structs[1].Fields[2].RefType.Name).To(Equal("User"))
-			Expect(pkg.Structs[1].Fields[3].RefType.Name).To(Equal("User"))
+			Expect(pkg.Structs[1].Fields[0].RefType.Name()).To(Equal("int64"))
+			Expect(pkg.Structs[1].Fields[1].RefType.Name()).To(Equal("string"))
+			Expect(pkg.Structs[1].Fields[2].RefType.Name()).To(Equal("User"))
+			Expect(pkg.Structs[1].Fields[3].RefType.Name()).To(Equal("User"))
 
-			Expect(pkg.Structs[1].Fields[0].RefType.Type).To(BeNil())
-			Expect(pkg.Structs[1].Fields[1].RefType.Type).To(BeNil())
-			Expect(pkg.Structs[1].Fields[2].RefType.Type).To(Equal(pkg.Structs[0]))
-			Expect(pkg.Structs[1].Fields[3].RefType.Type).To(Equal(pkg.Structs[0]))
+			Expect(pkg.Structs[1].Fields[0].RefType.Type()).To(BeNil())
+			Expect(pkg.Structs[1].Fields[1].RefType.Type()).To(BeNil())
+			Expect(pkg.Structs[1].Fields[2].RefType.Type()).To(Equal(pkg.Structs[0]))
+			Expect(pkg.Structs[1].Fields[3].RefType.Type()).To(Equal(pkg.Structs[0]))
 		})
 
 		It("should check struct tags", func() {
@@ -179,9 +179,9 @@ var _ = Describe("My AST Hurts - Parse simples files with tags and func from str
 
 			Expect(pkg.Structs).To(HaveLen(2))
 			Expect(pkg.Structs[0].Fields).To(HaveLen(2))
-			Expect(pkg.Structs[0].Fields[1].RefType.Name).To(Equal("User"))
-			Expect(pkg.Structs[0].Fields[1].RefType.Type).To(Equal(pkg.Structs[1]))
-			Expect(pkg.Structs[0].Fields[1].RefType.Pkg).To(Equal(pkg))
+			Expect(pkg.Structs[0].Fields[1].RefType.Name()).To(Equal("User"))
+			Expect(pkg.Structs[0].Fields[1].RefType.Type()).To(Equal(pkg.Structs[1]))
+			Expect(pkg.Structs[0].Fields[1].RefType.Pkg()).To(Equal(pkg))
 
 		})
 
@@ -288,7 +288,7 @@ var _ = Describe("My AST Hurts - Parse simples files with tags and func from str
 			Expect(ref).To(Equal(g.RefType))
 
 			Expect(g.RefType.Type).ToNot(BeNil())
-			Expect(g.RefType.Type.Name()).To(Equal("User"))
+			Expect(g.RefType.Type().Name()).To(Equal("User"))
 
 			ref, ok = pkg.RefTypeByName("string")
 			Expect(ok).To(BeTrue())
@@ -368,27 +368,23 @@ var _ = Describe("My AST Hurts - Parse simples files with tags and func from str
 			Expect(ok).To(BeTrue())
 			Expect(pkg.Name).To(Equal("models"))
 
-			Expect(pkg.Methods).To(HaveLen(3))
-			Expect(pkg.Methods[0].Name()).To(Equal("getName"))
-			Expect(pkg.Methods[0].Arguments).To(BeEmpty())
-			Expect(pkg.Methods[0].Recv).To(HaveLen(1))
+			Expect(pkg.Methods).To(HaveLen(2))
+			Expect(pkg.Methods[0].Name()).To(Equal("show"))
+			Expect(pkg.Methods[0].Arguments).To(HaveLen(2))
+			Expect(pkg.Methods[0].Recv).To(BeEmpty())
 
-			Expect(pkg.Methods[1].Name()).To(Equal("show"))
-			Expect(pkg.Methods[1].Arguments).To(HaveLen(2))
+			Expect(pkg.Methods[0].Arguments[0].Name).To(Equal("name"))
+			Expect(pkg.Methods[0].Arguments[1].Name).To(Equal("age"))
+
+			Expect(pkg.Methods[0].Arguments[0].Type.Type()).To(BeNil())
+			Expect(pkg.Methods[0].Arguments[1].Type.Type()).To(BeNil())
+
+			Expect(pkg.Methods[0].Arguments[0].Type.Name()).To(Equal("string"))
+			Expect(pkg.Methods[0].Arguments[1].Type.Name()).To(Equal("int64"))
+
+			Expect(pkg.Methods[1].Name()).To(Equal("welcome"))
+			Expect(pkg.Methods[1].Arguments).To(BeEmpty())
 			Expect(pkg.Methods[1].Recv).To(BeEmpty())
-
-			Expect(pkg.Methods[1].Arguments[0].Name).To(Equal("name"))
-			Expect(pkg.Methods[1].Arguments[1].Name).To(Equal("age"))
-
-			Expect(pkg.Methods[1].Arguments[0].Type.Type).To(BeNil())
-			Expect(pkg.Methods[1].Arguments[1].Type.Type).To(BeNil())
-
-			Expect(pkg.Methods[1].Arguments[0].Type.Name).To(Equal("string"))
-			Expect(pkg.Methods[1].Arguments[1].Type.Name).To(Equal("int64"))
-
-			Expect(pkg.Methods[2].Name()).To(Equal("welcome"))
-			Expect(pkg.Methods[2].Arguments).To(BeEmpty())
-			Expect(pkg.Methods[2].Recv).To(BeEmpty())
 
 		})
 
@@ -402,17 +398,15 @@ var _ = Describe("My AST Hurts - Parse simples files with tags and func from str
 			pkg, ok := env.PackageByImportPath("data")
 			Expect(ok).To(BeTrue())
 
-			Expect(pkg.Methods).To(HaveLen(2))
+			Expect(pkg.Methods).To(HaveLen(1))
+			Expect(pkg.Methods[0].Name()).To(Equal("getName_"))
 
 			Expect(pkg.Structs).To(HaveLen(1))
-			Expect(pkg.Structs[0].Methods).To(HaveLen(1))
-			Expect(pkg.Structs[0].Methods[0].Descriptor.Name()).To(Equal("getName"))
-			Expect(pkg.Structs[0].Methods[0].Descriptor.Arguments).To(BeEmpty())
-			Expect(pkg.Structs[0].Methods[0].Descriptor.Recv).To(HaveLen(1))
-			Expect(pkg.Structs[0].Methods[0].Descriptor.Recv[0].Type.Type).To(Equal(pkg.Structs[0]))
-
-			Expect(pkg.Methods[0].Name()).To(Equal("getName"))
-			Expect(pkg.Methods[1].Name()).To(Equal("getName_"))
+			Expect(pkg.Structs[0].Methods()).To(HaveLen(1))
+			Expect(pkg.Structs[0].Methods()[0].Descriptor.Name()).To(Equal("getName"))
+			Expect(pkg.Structs[0].Methods()[0].Descriptor.Arguments).To(BeEmpty())
+			Expect(pkg.Structs[0].Methods()[0].Descriptor.Recv).To(HaveLen(1))
+			Expect(pkg.Structs[0].Methods()[0].Descriptor.Recv[0].Type.Type()).To(Equal(pkg.Structs[0]))
 
 		})
 
@@ -426,9 +420,8 @@ var _ = Describe("My AST Hurts - Parse simples files with tags and func from str
 			pkg, ok := env.PackageByImportPath("data")
 			Expect(ok).To(BeTrue())
 
-			Expect(pkg.Methods).To(HaveLen(2))
+			Expect(pkg.Methods).To(HaveLen(1))
 			Expect(pkg.Methods[0].Package()).To(Equal(pkg))
-
 		})
 	})
 
@@ -480,11 +473,11 @@ var _ = Describe("My AST Hurts - Parse simples files with tags and func from str
 			ref, ok := bytes.RefTypeByName("Buffer")
 			Expect(ok).To(BeTrue())
 			Expect(ref).ToNot(BeNil())
-			Expect(models.Methods[0].Arguments[0].Type.Name).To(Equal(ref.Type.Name()))
+			Expect(models.Methods[0].Arguments[0].Type.Name()).To(Equal(ref.Type().Name()))
 
 			stct := bytes.StructByName("Buffer")
 			Expect(stct).ToNot(BeNil())
-			Expect(fmt.Sprintf("%p", models.Methods[0].Arguments[0].Type.Type)).To(Equal(fmt.Sprintf("%p", stct)))
+			Expect(fmt.Sprintf("%p", models.Methods[0].Arguments[0].Type.Type())).To(Equal(fmt.Sprintf("%p", stct)))
 		})
 	})
 
@@ -557,14 +550,11 @@ var _ = Describe("My AST Hurts - Parse simples files with tags and func from str
 			Expect(pkg.Doc.Comments).To(HaveLen(7))
 			Expect(pkg.Doc.Comments[0]).To(Equal("// Package models is a test"))
 
-			Expect(pkg.Methods).To(HaveLen(3))
+			Expect(pkg.Methods).To(HaveLen(2))
 			Expect(pkg.Methods[0].Doc.Comments).To(HaveLen(1))
-			Expect(pkg.Methods[0].Doc.Comments[0]).To(Equal("// Comment here"))
-			Expect(pkg.Methods[1].Doc.Comments).To(HaveLen(1))
-			Expect(pkg.Methods[1].Doc.Comments[0]).To(Equal("/** Description \n    multilines\n*/"))
-
+			Expect(pkg.Methods[0].Doc.Comments[0]).To(Equal("/** Description\n  multilines\n*/"))
+			Expect(pkg.Methods[1].Doc.Comments).To(BeEmpty())
 		})
-
 	})
 
 	When("parsing builtin file", func() {

--- a/experiment_test.go
+++ b/experiment_test.go
@@ -25,50 +25,49 @@ var _ = Describe("My AST Hurts - Parse simples files with tags and func from str
 			os.Setenv("GOROOT", GOROOT)
 		})
 
-		It("should show error if GOROOT not exist", func() {
+		PIt("should show error if GOROOT not exist", func() {
 			path := os.Getenv("GOROOT")
 			Expect(path).ToNot(BeEmpty())
 
-			exrr := os.Setenv("GOROOT", "")
-			Expect(exrr).ShouldNot(HaveOccurred())
+			err := os.Setenv("GOROOT", "")
+			Expect(err).ShouldNot(HaveOccurred())
 
-			_, exrr = NewEnvironment()
-			Expect(exrr).To(HaveOccurred())
-			Expect("GOROOT environment variable not found or is empty").To(Equal(exrr.Error()))
+			_, err = NewEnvironment()
+			Expect(err).To(HaveOccurred())
+			Expect("GOROOT environment variable not found or is empty").To(Equal(err.Error()))
 		})
 
-		It("should show error if GOROOT has incorrect value", func() {
+		PIt("should show error if GOROOT has incorrect value", func() {
 			path := os.Getenv("GOROOT")
 			Expect(path).ToNot(BeEmpty())
 
-			exrr := os.Setenv("GOROOT", "any")
-			Expect(exrr).ShouldNot(HaveOccurred())
+			err := os.Setenv("GOROOT", "any")
+			Expect(err).ShouldNot(HaveOccurred())
 
-			_, exrr = NewEnvironment()
-			Expect(exrr).To(HaveOccurred())
-			Expect("open any/src/builtin: no such file or directory").To(Equal(exrr.Error()))
+			_, err = NewEnvironment()
+			Expect(err).To(HaveOccurred())
+			Expect("open any/src/builtin: no such file or directory").To(Equal(err.Error()))
 		})
 
-		It("should show error if file not found", func() {
-			env, exrr := NewEnvironment()
-			Expect(exrr).To(BeNil())
+		PIt("should show error if file not found", func() {
+			env, err := NewEnvironment()
+			Expect(err).ToNot(HaveOccurred())
 
-			exrr = env.ParsePackage("data/models259.sample.go", true)
-			Expect(exrr).Should(HaveOccurred())
+			err = env.parse("data/models259.sample.go")
+			Expect(err).Should(HaveOccurred())
 
-			Expect("File not found").To(Equal(exrr.Error()))
+			Expect(err.Error()).To(ContainSubstring("no such file or directory"))
 		})
 
 	})
 
 	When("parsing struct", func() {
-
 		It("should check two struct in file and if anyName struct no exist", func() {
-			env, exrr := NewEnvironment()
-			Expect(exrr).To(BeNil())
+			env, err := NewEnvironment()
+			Expect(err).To(BeNil())
 
-			exrr = env.ParsePackage("data/models1.sample.go", true)
-			Expect(exrr).To(BeNil())
+			err = env.parse("data/models1.sample.go")
+			Expect(err).To(BeNil())
 
 			pkg, ok := env.PackageByName("models")
 			Expect(ok).To(BeTrue())
@@ -80,11 +79,11 @@ var _ = Describe("My AST Hurts - Parse simples files with tags and func from str
 		})
 
 		It("should check struct fields", func() {
-			env, exrr := NewEnvironment()
-			Expect(exrr).To(BeNil())
+			env, err := NewEnvironment()
+			Expect(err).ToNot(HaveOccurred())
 
-			exrr = env.ParsePackage("data/models2.sample.go", true)
-			Expect(exrr).To(BeNil())
+			err = env.parse("data/models2.sample.go")
+			Expect(err).ToNot(HaveOccurred())
 
 			pkg, ok := env.PackageByName("models")
 			Expect(ok).To(BeTrue())
@@ -129,7 +128,7 @@ var _ = Describe("My AST Hurts - Parse simples files with tags and func from str
 			env, exrr := NewEnvironment()
 			Expect(exrr).To(BeNil())
 
-			exrr = env.ParsePackage("data/models3.sample.go", true)
+			exrr = env.parse("data/models3.sample.go")
 			Expect(exrr).To(BeNil())
 
 			pkg, ok := env.PackageByName("models")
@@ -172,7 +171,7 @@ var _ = Describe("My AST Hurts - Parse simples files with tags and func from str
 			env, exrr := NewEnvironment()
 			Expect(exrr).To(BeNil())
 
-			exrr = env.ParsePackage("data/models4.sample.go", true)
+			exrr = env.parse("data/models4.sample.go")
 			Expect(exrr).To(BeNil())
 
 			pkg, ok := env.PackageByName("models")
@@ -191,7 +190,7 @@ var _ = Describe("My AST Hurts - Parse simples files with tags and func from str
 			env, exrr := NewEnvironment()
 			Expect(exrr).To(BeNil())
 
-			exrr = env.ParsePackage("data/models5.sample.go", true)
+			exrr = env.parse("data/models5.sample.go")
 			Expect(exrr).To(BeNil())
 
 			pkg, ok := env.PackageByName("models")
@@ -222,7 +221,7 @@ var _ = Describe("My AST Hurts - Parse simples files with tags and func from str
 				ASTI:    false,
 			}
 
-			exrr = env.ParsePackage("data/models11.sample.go", true)
+			exrr = env.parse("data/models11.sample.go")
 			builtin, _ := env.PackageByName("builtin")
 			Expect(builtin).ToNot(BeNil())
 			Expect(exrr).To(BeNil())
@@ -293,7 +292,7 @@ var _ = Describe("My AST Hurts - Parse simples files with tags and func from str
 				ASTI:    false,
 			}
 
-			exrr = env.ParsePackage("data/models15.sample.go", true)
+			exrr = env.parse("data/models15.sample.go")
 			builtin, _ := env.PackageByName("builtin")
 			Expect(builtin).ToNot(BeNil())
 			Expect(exrr).To(BeNil())
@@ -313,6 +312,26 @@ var _ = Describe("My AST Hurts - Parse simples files with tags and func from str
 			Expect(pkg.RefTypeByName("string")).To(Equal(b.RefType))
 		})
 
+		It("should check named types", func() {
+
+			env, exrr := NewEnvironment()
+			Expect(exrr).To(BeNil())
+			env.Config = EnvConfig{
+				DevMode: true,
+				ASTI:    false,
+			}
+
+			exrr = env.parse("data/models16.sample.go")
+			builtin, _ := env.PackageByName("builtin")
+			Expect(builtin).ToNot(BeNil())
+			Expect(exrr).To(BeNil())
+
+			_, ok := env.PackageByName("models")
+			Expect(ok).To(BeTrue())
+
+			/** WIP */
+		})
+
 	})
 
 	When("parsing function", func() {
@@ -322,7 +341,7 @@ var _ = Describe("My AST Hurts - Parse simples files with tags and func from str
 			env, exrr := NewEnvironment()
 			Expect(exrr).To(BeNil())
 
-			exrr = env.ParsePackage("data/models6.sample.go", true)
+			exrr = env.parse("data/models6.sample.go")
 			Expect(exrr).To(BeNil())
 
 			pkg, ok := env.PackageByName("models")
@@ -357,7 +376,7 @@ var _ = Describe("My AST Hurts - Parse simples files with tags and func from str
 			env, exrr := NewEnvironment()
 			Expect(exrr).To(BeNil())
 
-			exrr = env.ParsePackage("data/models7.sample.go", true)
+			exrr = env.parse("data/models7.sample.go")
 			Expect(exrr).To(BeNil())
 
 			pkg, ok := env.PackageByName("models")
@@ -381,7 +400,7 @@ var _ = Describe("My AST Hurts - Parse simples files with tags and func from str
 			env, exrr := NewEnvironment()
 			Expect(exrr).To(BeNil())
 
-			exrr = env.ParsePackage("data/models7.sample.go", true)
+			exrr = env.parse("data/models7.sample.go")
 			Expect(exrr).To(BeNil())
 
 			pkg, ok := env.PackageByName("models")
@@ -400,7 +419,7 @@ var _ = Describe("My AST Hurts - Parse simples files with tags and func from str
 			env, exrr := NewEnvironment()
 			Expect(exrr).To(BeNil())
 
-			exrr = env.ParsePackage("data/models8.sample.go", true)
+			exrr = env.parse("data/models8.sample.go")
 			Expect(exrr).To(BeNil())
 
 			models, _ := env.PackageByName("models")
@@ -418,11 +437,10 @@ var _ = Describe("My AST Hurts - Parse simples files with tags and func from str
 		})
 
 		It("should check the struct types of import package bytes with dot", func() {
-			env, exrr := NewEnvironment()
-			Expect(exrr).To(BeNil())
+			env, err := NewEnvironment()
+			Expect(err).To(BeNil())
 
-			exrr = env.ParsePackage("data/models12.sample.go", true)
-			Expect(exrr).To(BeNil())
+			Expect(env.parse("data/models12.sample.go")).To(Succeed())
 
 			models, ok := env.PackageByName("models")
 			Expect(ok).To(BeTrue())
@@ -452,7 +470,7 @@ var _ = Describe("My AST Hurts - Parse simples files with tags and func from str
 			env, exrr := NewEnvironment()
 			Expect(exrr).To(BeNil())
 
-			exrr = env.ParsePackage("data/models9.sample.go", true)
+			exrr = env.parse("data/models9.sample.go")
 			Expect(exrr).To(BeNil())
 
 			pkg, ok := env.PackageByName("models")
@@ -482,7 +500,7 @@ var _ = Describe("My AST Hurts - Parse simples files with tags and func from str
 			env, exrr := NewEnvironment()
 			Expect(exrr).To(BeNil())
 
-			exrr = env.ParsePackage("data/models14.sample.go", true)
+			exrr = env.parse("data/models14.sample.go")
 			Expect(exrr).To(BeNil())
 
 			pkg, ok := env.PackageByName("models")
@@ -505,7 +523,7 @@ var _ = Describe("My AST Hurts - Parse simples files with tags and func from str
 			env, exrr := NewEnvironment()
 			Expect(exrr).To(BeNil())
 
-			exrr = env.ParsePackage("data/models10.sample.go", true)
+			exrr = env.parse("data/models10.sample.go")
 			Expect(exrr).To(BeNil())
 
 			pkg, ok := env.PackageByName("models")
@@ -531,7 +549,7 @@ var _ = Describe("My AST Hurts - Parse simples files with tags and func from str
 			env, exrr := NewEnvironment()
 			Expect(exrr).To(BeNil())
 
-			exrr = env.ParsePackage("data/models13.sample.go", true)
+			exrr = env.parse("data/models13.sample.go")
 			Expect(exrr).To(BeNil())
 
 			pkgM, okM := env.PackageByName("models")
@@ -602,5 +620,4 @@ var _ = Describe("My AST Hurts - Parse simples files with tags and func from str
 		})
 
 	})
-
 })

--- a/experiment_test.go
+++ b/experiment_test.go
@@ -302,27 +302,6 @@ var _ = Describe("My AST Hurts - Parse simples files with tags and func from str
 			Expect(b).ToNot(BeNil())
 			Expect(b.RefType).ToNot(BeNil())
 		})
-
-		It("should check named types", func() {
-
-			env, exrr := NewEnvironment()
-			Expect(exrr).To(BeNil())
-			env.Config = EnvConfig{
-				DevMode: true,
-				ASTI:    false,
-			}
-
-			exrr = env.parseFile(newDataPackageContext(env), "data/models16.sample.go")
-			builtin, _ := env.PackageByImportPath("builtin")
-			Expect(builtin).ToNot(BeNil())
-			Expect(exrr).To(BeNil())
-
-			_, ok := env.PackageByImportPath("data")
-			Expect(ok).To(BeTrue())
-
-			/** WIP */
-		})
-
 	})
 
 	When("parsing function", func() {
@@ -522,7 +501,7 @@ var _ = Describe("My AST Hurts - Parse simples files with tags and func from str
 
 			Expect(pkg.Methods).To(HaveLen(2))
 			Expect(pkg.Methods[0].Doc.Comments).To(HaveLen(1))
-			Expect(pkg.Methods[0].Doc.Comments[0]).To(Equal("/** Description\n  multilines\n*/"))
+			Expect(pkg.Methods[0].Doc.Comments[0]).To(Equal("/** Description \n    multilines\n*/"))
 			Expect(pkg.Methods[1].Doc.Comments).To(BeEmpty())
 		})
 	})

--- a/experiment_test.go
+++ b/experiment_test.go
@@ -265,34 +265,12 @@ var _ = Describe("My AST Hurts - Parse simples files with tags and func from str
 			x := pkg.VariableByName("x")
 			Expect(x).To(BeNil())
 
-			ref, ok := pkg.RefTypeByName("string")
-			Expect(ok).To(BeTrue())
-			Expect(ref).To(Equal(a.RefType))
-			ref, ok = pkg.RefTypeByName("byte")
-			Expect(ok).To(BeTrue())
-			Expect(ref).To(Equal(b.RefType))
-			ref, ok = pkg.RefTypeByName("int")
-			Expect(ok).To(BeTrue())
-			Expect(ref).To(Equal(c.RefType))
-			ref, ok = pkg.RefTypeByName("int64")
-			Expect(ok).To(BeTrue())
-			Expect(ref).To(Equal(d.RefType))
-			ref, ok = pkg.RefTypeByName("float32")
-			Expect(ok).To(BeTrue())
-			Expect(ref).To(Equal(e.RefType))
-			ref, ok = pkg.RefTypeByName("bool")
-			Expect(ok).To(BeTrue())
-			Expect(ref).To(Equal(f.RefType))
-			ref, ok = pkg.RefTypeByName("User")
+			ref, ok := pkg.RefTypeByName("User")
 			Expect(ok).To(BeTrue())
 			Expect(ref).To(Equal(g.RefType))
 
 			Expect(g.RefType.Type).ToNot(BeNil())
 			Expect(g.RefType.Type().Name()).To(Equal("User"))
-
-			ref, ok = pkg.RefTypeByName("string")
-			Expect(ok).To(BeTrue())
-			Expect(ref).To(Equal(h.RefType))
 
 			/* Obs: At the moment it is not possible to identify if
 			 * 		the variable is array or no. (This is necessary?)
@@ -323,13 +301,6 @@ var _ = Describe("My AST Hurts - Parse simples files with tags and func from str
 			b := pkg.VariableByName("OLM")
 			Expect(b).ToNot(BeNil())
 			Expect(b.RefType).ToNot(BeNil())
-
-			ref, ok := pkg.RefTypeByName("float")
-			Expect(ok).To(BeTrue())
-			Expect(ref).To(Equal(a.RefType))
-			ref, ok = pkg.RefTypeByName("string")
-			Expect(ok).To(BeTrue())
-			Expect(ref).To(Equal(b.RefType))
 		})
 
 		It("should check named types", func() {
@@ -456,7 +427,6 @@ var _ = Describe("My AST Hurts - Parse simples files with tags and func from str
 			Expect(err).ToNot(HaveOccurred())
 
 			dataPkgCtx := newDataPackageContext(env)
-			env.AppendPackage(dataPkgCtx.Package)
 			Expect(env.parseFile(dataPkgCtx, "data/models12.sample.go")).To(Succeed())
 
 			models, ok := env.PackageByImportPath("data")

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/mattn/go-isatty v0.0.9 // indirect
 	github.com/onsi/ginkgo v1.10.1
 	github.com/onsi/gomega v1.7.0
-	github.com/pkg/errors v0.8.1 // indirect
+	github.com/pkg/errors v0.8.1
 	github.com/valyala/fasthttp v1.5.0 // indirect
 	golang.org/x/tools v0.0.0-20190906203814-12febf440ab1
 	gopkg.in/go-playground/validator.v9 v9.30.0 // indirect


### PR DESCRIPTION
### :sparkles: Enhacements
* Adds support for discovering package information by using the `go/build` dependency;
* Refactor how `Package`s are identified in the `environment`. Thanks to `go/build`, now packages are identified by the `ImportPath`.
* Merge all `ast.Expr` type parse into one function: `parseType`;
* Add support for representing pointers, arrays, function types, channels and maps.

### :recycle: Refactoring
* Change a couple method names to explicit its usage;
* Refactor `RefType` into an interface, the old `RefType` is not `BaseRefType`;
* Apply `parseType` into all 

### :bug: Bugs
* Fix a lot of errors that were ignored and not propagated.