### PR TITLE
Implement parsing interfaces

### DIFF
--- a/data/interface.go
+++ b/data/interface.go
@@ -1,0 +1,28 @@
+package models
+
+type HasName interface {
+	Name() string
+	SetName(value string)
+}
+
+type HasAge interface {
+	Age() int
+	SetAge(value int)
+}
+
+type HasNameWrong interface {
+	Name() string
+	SetName(value int)
+}
+
+type InterfaceUser struct {
+	name string
+}
+
+func (u *InterfaceUser) Name() string {
+	return u.name
+}
+
+func (u *InterfaceUser) SetName(value string) {
+	u.name = value
+}

--- a/data/interface.go
+++ b/data/interface.go
@@ -1,5 +1,7 @@
 package models
 
+import "io"
+
 type HasName interface {
 	Name() string
 	SetName(value string)
@@ -11,6 +13,7 @@ type HasAge interface {
 }
 
 type HasNameWrong interface {
+	io.Reader
 	Name() string
 	SetName(value int)
 }

--- a/definitions.go
+++ b/definitions.go
@@ -47,34 +47,6 @@ type File struct {
 	Files      []*File
 }
 
-type Interface struct {
-	pkg     *Package
-	name    string
-	Methods []MethodDescriptor
-	Doc     Doc
-}
-
-// MethodArgument represent type of fields and arguments.
-type MethodArgument struct {
-	Name string
-	Type RefType
-	Doc  Doc
-}
-
-type MethodDescriptor struct {
-	baseType
-	Doc       Doc
-	Recv      []MethodArgument
-	Arguments []MethodArgument
-	Result    []MethodResult
-	Tag       Tag
-}
-
-type MethodResult struct {
-	Name string
-	Type Type
-}
-
 type Package struct {
 	Name        string
 	ImportPath  string
@@ -361,13 +333,6 @@ func (t *baseType) AddMethod(method *TypeMethod) {
 	t.methods = append(t.methods, method)
 }
 
-type Struct struct {
-	baseType
-	Doc        Doc
-	Fields     []*Field
-	Interfaces []*Interface
-}
-
 type TypeMethod struct {
 	Name       string
 	Descriptor *MethodDescriptor
@@ -402,41 +367,6 @@ func (doc *Doc) FormatComment() string {
 		}
 	}
 	return str
-}
-
-// NewInterface Create new Interface.
-func NewInterface(pkg *Package, name string) *Interface {
-	return &Interface{
-		pkg:  pkg,
-		name: name,
-	}
-}
-
-// Package get name of Pacakge.
-func (i *Interface) Package() *Package {
-	return i.pkg
-}
-
-// Name return name of Struct than implement this Interface.
-func (i *Interface) Name() string {
-	return i.name
-}
-
-// NewMethodDescriptor return the pointer of new MethodDescriptor
-func NewMethodDescriptor(pkg *Package, name string) *MethodDescriptor {
-	return &MethodDescriptor{
-		baseType: *NewBaseType(pkg, name),
-	}
-}
-
-// Package return pointer of Package
-func (method *MethodDescriptor) Package() *Package {
-	return method.pkg
-}
-
-// Name return name of Method
-func (method *MethodDescriptor) Name() string {
-	return method.name
 }
 
 // AppendStruct add new Struct in Package
@@ -514,41 +444,6 @@ func (p *Package) AppendVariable(variable *Variable) *Variable {
 	p.Variables = append(p.Variables, variable)
 	return variable
 }
-
-// NewStruct return new pointer Struct
-func NewStruct(pkg *Package, name string) *Struct {
-	srct := &Struct{
-		baseType: baseType{
-			pkg:  pkg,
-			name: name,
-		},
-	}
-	return srct
-}
-
-// Package return pointer package of Struct
-func (s *Struct) Package() *Package {
-	return s.pkg
-}
-
-// Name return name of Struct
-func (s *Struct) Name() string {
-	return s.name
-}
-
-// FormatComments show struct with all comments
-/*func (s *Struct) FormatComments() string {
-	str := fmt.Sprintf("%s\ntype %s struct {\n", s.Doc.FormatComment(), s.Name())
-	for _, f := range s.Fields {
-		c := f.Doc.FormatComment()
-		brk := "\n"
-		if c == "" {
-			brk = ""
-		}
-		str += fmt.Sprintf("%s%s%s %s %s\n", c, brk, f.Name, f.RefType.Name, f.Tag.Raw)
-	}
-	return fmt.Sprintf("%s}", str)
-}*/
 
 // AppendTagParam add new TagParam in Tag
 func (t *Tag) AppendTagParam(tNew *TagParam) bool {

--- a/environment.go
+++ b/environment.go
@@ -31,6 +31,7 @@ func NewPackageContext(pkg *Package, buildPackage *build.Package) *parsePackageC
 // parseFileContext will keep all information needed for parsing a single file.
 type parseFileContext struct {
 	File                  *ast.File
+	FSet                  *token.FileSet
 	Env                   *environment
 	Package               *Package
 	dotImports            []*Package
@@ -225,6 +226,7 @@ func (env *environment) parseFile(pkgCtx *parsePackageContext, filePath string) 
 	// Create the context of the file parse.
 	fileCtx := &parseFileContext{
 		File:                  file,
+		FSet:                  fset,
 		Env:                   env,
 		Package:               pkgCtx.Package,
 		dotImports:            dotImports,

--- a/experiment_test.go
+++ b/experiment_test.go
@@ -335,6 +335,14 @@ var _ = Describe("My AST Hurts - Parse simples files with tags and func from str
 			Expect(pkg.Methods[1].Name()).To(Equal("welcome"))
 			Expect(pkg.Methods[1].Arguments).To(BeEmpty())
 			Expect(pkg.Methods[1].Recv).To(BeEmpty())
+			Expect(pkg.Methods[1].Result).To(HaveLen(1))
+			Expect(pkg.Methods[1].Result[0].Type.Name()).To(Equal("string"))
+
+			Expect(pkg.methodsMap).To(HaveLen(2))
+			Expect(pkg.methodsMap).To(HaveKey("show"))
+			Expect(pkg.methodsMap).To(HaveKey("welcome"))
+
+			Expect(pkg.Methods[0].Name()).To(Equal("show"))
 
 		})
 
@@ -357,7 +365,10 @@ var _ = Describe("My AST Hurts - Parse simples files with tags and func from str
 			Expect(pkg.Structs[0].Methods()[0].Descriptor.Arguments).To(BeEmpty())
 			Expect(pkg.Structs[0].Methods()[0].Descriptor.Recv).To(HaveLen(1))
 			Expect(pkg.Structs[0].Methods()[0].Descriptor.Recv[0].Type.Type()).To(Equal(pkg.Structs[0]))
-
+			Expect(pkg.Structs[0].Methods()[0].Descriptor.Result).To(HaveLen(1))
+			Expect(pkg.Structs[0].Methods()[0].Descriptor.Result[0].Type.Name()).To(Equal("string"))
+			Expect(pkg.Structs[0].methodsMap).To(HaveLen(1))
+			Expect(pkg.Structs[0].methodsMap).To(HaveKey("getName"))
 		})
 
 		It("should check package of func", func() {
@@ -424,7 +435,8 @@ var _ = Describe("My AST Hurts - Parse simples files with tags and func from str
 			Expect(ref).ToNot(BeNil())
 			Expect(models.Methods[0].Arguments[0].Type.Name()).To(Equal(ref.Type().Name()))
 
-			stct := bytes.StructByName("Buffer")
+			stct, ok := bytes.StructByName("Buffer")
+			Expect(ok).To(BeTrue())
 			Expect(stct).ToNot(BeNil())
 			Expect(fmt.Sprintf("%p", models.Methods[0].Arguments[0].Type.Type())).To(Equal(fmt.Sprintf("%p", stct)))
 		})

--- a/interface.go
+++ b/interface.go
@@ -1,26 +1,13 @@
 package myasthurts
 
 type Interface struct {
-	pkg     *Package
-	name    string
-	Methods []MethodDescriptor
-	Doc     Doc
+	baseType
+	Doc Doc
 }
 
 // NewInterface Create new Interface.
 func NewInterface(pkg *Package, name string) *Interface {
 	return &Interface{
-		pkg:  pkg,
-		name: name,
+		baseType: *NewBaseType(pkg, name),
 	}
-}
-
-// Package get name of Pacakge.
-func (i *Interface) Package() *Package {
-	return i.pkg
-}
-
-// Name return name of Struct than implement this Interface.
-func (i *Interface) Name() string {
-	return i.name
 }

--- a/interface.go
+++ b/interface.go
@@ -1,0 +1,26 @@
+package myasthurts
+
+type Interface struct {
+	pkg     *Package
+	name    string
+	Methods []MethodDescriptor
+	Doc     Doc
+}
+
+// NewInterface Create new Interface.
+func NewInterface(pkg *Package, name string) *Interface {
+	return &Interface{
+		pkg:  pkg,
+		name: name,
+	}
+}
+
+// Package get name of Pacakge.
+func (i *Interface) Package() *Package {
+	return i.pkg
+}
+
+// Name return name of Struct than implement this Interface.
+func (i *Interface) Name() string {
+	return i.name
+}

--- a/interface_test.go
+++ b/interface_test.go
@@ -1,0 +1,56 @@
+package myasthurts
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Interface", func() {
+	Describe("Parse", func() {
+		It("should parse interfaces", func() {
+			env, err := NewEnvironment()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(env.parseFile(newDataPackageContext(env), "data/interface.go")).To(Succeed())
+
+			pkg, ok := env.PackageByImportPath("data")
+			Expect(ok).To(BeTrue())
+
+			Expect(pkg.Interfaces).To(HaveLen(3))
+			Expect(pkg.Interfaces[0].Name()).To(Equal("HasName"))
+			Expect(pkg.Interfaces[0].Methods()).To(HaveLen(2))
+			Expect(pkg.Interfaces[0].Methods()[0].Descriptor.Name()).To(Equal("Name"))
+			Expect(pkg.Interfaces[0].Methods()[0].Descriptor.Arguments).To(BeEmpty())
+			Expect(pkg.Interfaces[0].Methods()[1].Descriptor.Name()).To(Equal("SetName"))
+			Expect(pkg.Interfaces[0].Methods()[1].Descriptor.Arguments).To(HaveLen(1))
+			Expect(pkg.Interfaces[0].Methods()[1].Descriptor.Arguments[0].Name).To(Equal("value"))
+			Expect(pkg.Interfaces[0].Methods()[1].Descriptor.Arguments[0].Type.Name()).To(Equal("string"))
+			Expect(pkg.Interfaces[0].methodsMap).To(HaveLen(2))
+			Expect(pkg.Interfaces[0].methodsMap).To(HaveKey("Name"))
+			Expect(pkg.Interfaces[0].methodsMap).To(HaveKey("SetName"))
+			Expect(pkg.Interfaces[0].Methods()[1].Descriptor.Arguments[0].Type.Name()).To(Equal("string"))
+			Expect(pkg.Interfaces[1].Name()).To(Equal("HasAge"))
+			Expect(pkg.Interfaces[1].Methods()).To(HaveLen(2))
+			Expect(pkg.Interfaces[1].Methods()[0].Descriptor.Name()).To(Equal("Age"))
+			Expect(pkg.Interfaces[1].Methods()[0].Descriptor.Arguments).To(BeEmpty())
+			Expect(pkg.Interfaces[1].Methods()[1].Descriptor.Name()).To(Equal("SetAge"))
+			Expect(pkg.Interfaces[1].Methods()[1].Descriptor.Arguments).To(HaveLen(1))
+			Expect(pkg.Interfaces[1].Methods()[1].Descriptor.Arguments[0].Name).To(Equal("value"))
+			Expect(pkg.Interfaces[1].Methods()[1].Descriptor.Arguments[0].Type.Name()).To(Equal("int"))
+			Expect(pkg.Interfaces[1].methodsMap).To(HaveLen(2))
+			Expect(pkg.Interfaces[1].methodsMap).To(HaveKey("Age"))
+			Expect(pkg.Interfaces[1].methodsMap).To(HaveKey("SetAge"))
+			Expect(pkg.Interfaces[2].Name()).To(Equal("HasNameWrong"))
+			Expect(pkg.Interfaces[2].Methods()).To(HaveLen(2))
+			Expect(pkg.Interfaces[2].Methods()[0].Descriptor.Name()).To(Equal("Name"))
+			Expect(pkg.Interfaces[2].Methods()[0].Descriptor.Arguments).To(BeEmpty())
+			Expect(pkg.Interfaces[2].Methods()[1].Descriptor.Name()).To(Equal("SetName"))
+			Expect(pkg.Interfaces[2].Methods()[1].Descriptor.Arguments).To(HaveLen(1))
+			Expect(pkg.Interfaces[2].Methods()[1].Descriptor.Arguments[0].Name).To(Equal("value"))
+			Expect(pkg.Interfaces[2].Methods()[1].Descriptor.Arguments[0].Type.Name()).To(Equal("int"))
+			Expect(pkg.Interfaces[2].methodsMap).To(HaveLen(2))
+			Expect(pkg.Interfaces[2].methodsMap).To(HaveKey("Name"))
+			Expect(pkg.Interfaces[2].methodsMap).To(HaveKey("SetName"))
+		})
+	})
+})

--- a/method.go
+++ b/method.go
@@ -1,0 +1,39 @@
+package myasthurts
+
+// MethodArgument represent type of fields and arguments.
+type MethodArgument struct {
+	Name string
+	Type RefType
+	Doc  Doc
+}
+
+type MethodDescriptor struct {
+	baseType
+	Doc       Doc
+	Recv      []MethodArgument
+	Arguments []MethodArgument
+	Result    []MethodResult
+	Tag       Tag
+}
+
+type MethodResult struct {
+	Name string
+	Type Type
+}
+
+// NewMethodDescriptor return the pointer of new MethodDescriptor
+func NewMethodDescriptor(pkg *Package, name string) *MethodDescriptor {
+	return &MethodDescriptor{
+		baseType: *NewBaseType(pkg, name),
+	}
+}
+
+// Package return pointer of Package
+func (method *MethodDescriptor) Package() *Package {
+	return method.pkg
+}
+
+// Name return name of Method
+func (method *MethodDescriptor) Name() string {
+	return method.name
+}

--- a/method.go
+++ b/method.go
@@ -18,7 +18,7 @@ type MethodDescriptor struct {
 
 type MethodResult struct {
 	Name string
-	Type Type
+	Type RefType
 }
 
 // NewMethodDescriptor return the pointer of new MethodDescriptor
@@ -36,4 +36,30 @@ func (method *MethodDescriptor) Package() *Package {
 // Name return name of Method
 func (method *MethodDescriptor) Name() string {
 	return method.name
+}
+
+// Compatible checks if the signature of both method descriptor are compatible.
+//
+// It checks if the all arguments refer to the same RefType. The same happens
+// with the result.
+//
+// Receivers are not taken into consideration, neither names.
+func (method *MethodDescriptor) Compatible(m *MethodDescriptor) bool {
+	if len(method.Arguments) != len(m.Arguments) {
+		return false
+	}
+	if len(method.Result) != len(m.Result) {
+		return false
+	}
+	for i, arg := range method.Arguments {
+		if m.Arguments[i].Type != arg.Type {
+			return false
+		}
+	}
+	for i, r := range method.Result {
+		if m.Result[i].Type != r.Type {
+			return false
+		}
+	}
+	return true
 }

--- a/method_test.go
+++ b/method_test.go
@@ -1,0 +1,229 @@
+package myasthurts
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("MethodDescriptor", func() {
+	Describe("Compatible", func() {
+		It("should find methods compatible", func() {
+			ref1 := NewRefType("ref1", nil, nil)
+			ref2 := NewRefType("ref2", nil, nil)
+			ref3 := NewRefType("ref3", nil, nil)
+			md1 := MethodDescriptor{
+				baseType: baseType{},
+				Arguments: []MethodArgument{
+					{
+						Type: ref1,
+					},
+					{
+						Type: ref2,
+					},
+				},
+				Result: []MethodResult{
+					{
+						Type: ref3,
+					},
+					{
+						Type: ref2,
+					},
+				},
+			}
+			md2 := MethodDescriptor{
+				baseType: baseType{},
+				Arguments: []MethodArgument{
+					{
+						Type: ref1,
+					},
+					{
+						Type: ref2,
+					},
+				},
+				Result: []MethodResult{
+					{
+						Type: ref3,
+					},
+					{
+						Type: ref2,
+					},
+				},
+			}
+			Expect(md1.Compatible(&md2)).To(BeTrue())
+		})
+
+		It("should find methods not compatible with argument length difference", func() {
+			ref1 := NewRefType("ref1", nil, nil)
+			ref2 := NewRefType("ref2", nil, nil)
+			ref3 := NewRefType("ref3", nil, nil)
+			md1 := MethodDescriptor{
+				baseType: baseType{},
+				Arguments: []MethodArgument{
+					{
+						Type: ref1,
+					},
+					{
+						Type: ref2,
+					},
+				},
+				Result: []MethodResult{
+					{
+						Type: ref3,
+					},
+					{
+						Type: ref2,
+					},
+				},
+			}
+			md2 := MethodDescriptor{
+				baseType: baseType{},
+				Arguments: []MethodArgument{
+					{
+						Type: ref1,
+					},
+				},
+				Result: []MethodResult{
+					{
+						Type: ref3,
+					},
+					{
+						Type: ref2,
+					},
+				},
+			}
+			Expect(md1.Compatible(&md2)).To(BeFalse())
+		})
+
+		It("should find methods not compatible with result length difference", func() {
+			ref1 := NewRefType("ref1", nil, nil)
+			ref2 := NewRefType("ref2", nil, nil)
+			ref3 := NewRefType("ref3", nil, nil)
+			md1 := MethodDescriptor{
+				baseType: baseType{},
+				Arguments: []MethodArgument{
+					{
+						Type: ref1,
+					},
+					{
+						Type: ref2,
+					},
+				},
+				Result: []MethodResult{
+					{
+						Type: ref3,
+					},
+					{
+						Type: ref2,
+					},
+				},
+			}
+			md2 := MethodDescriptor{
+				baseType: baseType{},
+				Arguments: []MethodArgument{
+					{
+						Type: ref1,
+					},
+					{
+						Type: ref2,
+					},
+				},
+				Result: []MethodResult{
+					{
+						Type: ref3,
+					},
+				},
+			}
+			Expect(md1.Compatible(&md2)).To(BeFalse())
+		})
+
+		It("should find methods not compatible with argument types different", func() {
+			ref1 := NewRefType("ref1", nil, nil)
+			ref2 := NewRefType("ref2", nil, nil)
+			ref3 := NewRefType("ref3", nil, nil)
+			md1 := MethodDescriptor{
+				baseType: baseType{},
+				Arguments: []MethodArgument{
+					{
+						Type: ref1,
+					},
+					{
+						Type: ref3,
+					},
+				},
+				Result: []MethodResult{
+					{
+						Type: ref3,
+					},
+					{
+						Type: ref2,
+					},
+				},
+			}
+			md2 := MethodDescriptor{
+				baseType: baseType{},
+				Arguments: []MethodArgument{
+					{
+						Type: ref1,
+					},
+					{
+						Type: ref2,
+					},
+				},
+				Result: []MethodResult{
+					{
+						Type: ref3,
+					},
+					{
+						Type: ref2,
+					},
+				},
+			}
+			Expect(md1.Compatible(&md2)).To(BeFalse())
+		})
+
+		It("should find methods not compatible with result types different", func() {
+			ref1 := NewRefType("ref1", nil, nil)
+			ref2 := NewRefType("ref2", nil, nil)
+			ref3 := NewRefType("ref3", nil, nil)
+			md1 := MethodDescriptor{
+				baseType: baseType{},
+				Arguments: []MethodArgument{
+					{
+						Type: ref1,
+					},
+					{
+						Type: ref2,
+					},
+				},
+				Result: []MethodResult{
+					{
+						Type: ref3,
+					},
+					{
+						Type: ref1,
+					},
+				},
+			}
+			md2 := MethodDescriptor{
+				baseType: baseType{},
+				Arguments: []MethodArgument{
+					{
+						Type: ref1,
+					},
+					{
+						Type: ref2,
+					},
+				},
+				Result: []MethodResult{
+					{
+						Type: ref3,
+					},
+					{
+						Type: ref2,
+					},
+				},
+			}
+			Expect(md1.Compatible(&md2)).To(BeFalse())
+		})
+	})
+})

--- a/method_test.go
+++ b/method_test.go
@@ -12,7 +12,7 @@ var _ = Describe("MethodDescriptor", func() {
 			ref2 := NewRefType("ref2", nil, nil)
 			ref3 := NewRefType("ref3", nil, nil)
 			md1 := MethodDescriptor{
-				baseType: baseType{},
+				baseType: *NewBaseType(nil, ""),
 				Arguments: []MethodArgument{
 					{
 						Type: ref1,
@@ -31,7 +31,7 @@ var _ = Describe("MethodDescriptor", func() {
 				},
 			}
 			md2 := MethodDescriptor{
-				baseType: baseType{},
+				baseType: *NewBaseType(nil, ""),
 				Arguments: []MethodArgument{
 					{
 						Type: ref1,
@@ -57,7 +57,7 @@ var _ = Describe("MethodDescriptor", func() {
 			ref2 := NewRefType("ref2", nil, nil)
 			ref3 := NewRefType("ref3", nil, nil)
 			md1 := MethodDescriptor{
-				baseType: baseType{},
+				baseType: *NewBaseType(nil, ""),
 				Arguments: []MethodArgument{
 					{
 						Type: ref1,
@@ -76,7 +76,7 @@ var _ = Describe("MethodDescriptor", func() {
 				},
 			}
 			md2 := MethodDescriptor{
-				baseType: baseType{},
+				baseType: *NewBaseType(nil, ""),
 				Arguments: []MethodArgument{
 					{
 						Type: ref1,
@@ -99,7 +99,7 @@ var _ = Describe("MethodDescriptor", func() {
 			ref2 := NewRefType("ref2", nil, nil)
 			ref3 := NewRefType("ref3", nil, nil)
 			md1 := MethodDescriptor{
-				baseType: baseType{},
+				baseType: *NewBaseType(nil, ""),
 				Arguments: []MethodArgument{
 					{
 						Type: ref1,
@@ -118,7 +118,7 @@ var _ = Describe("MethodDescriptor", func() {
 				},
 			}
 			md2 := MethodDescriptor{
-				baseType: baseType{},
+				baseType: *NewBaseType(nil, ""),
 				Arguments: []MethodArgument{
 					{
 						Type: ref1,
@@ -141,7 +141,7 @@ var _ = Describe("MethodDescriptor", func() {
 			ref2 := NewRefType("ref2", nil, nil)
 			ref3 := NewRefType("ref3", nil, nil)
 			md1 := MethodDescriptor{
-				baseType: baseType{},
+				baseType: *NewBaseType(nil, ""),
 				Arguments: []MethodArgument{
 					{
 						Type: ref1,
@@ -160,7 +160,7 @@ var _ = Describe("MethodDescriptor", func() {
 				},
 			}
 			md2 := MethodDescriptor{
-				baseType: baseType{},
+				baseType: *NewBaseType(nil, ""),
 				Arguments: []MethodArgument{
 					{
 						Type: ref1,
@@ -186,7 +186,7 @@ var _ = Describe("MethodDescriptor", func() {
 			ref2 := NewRefType("ref2", nil, nil)
 			ref3 := NewRefType("ref3", nil, nil)
 			md1 := MethodDescriptor{
-				baseType: baseType{},
+				baseType: *NewBaseType(nil, ""),
 				Arguments: []MethodArgument{
 					{
 						Type: ref1,
@@ -205,7 +205,7 @@ var _ = Describe("MethodDescriptor", func() {
 				},
 			}
 			md2 := MethodDescriptor{
-				baseType: baseType{},
+				baseType: *NewBaseType(nil, ""),
 				Arguments: []MethodArgument{
 					{
 						Type: ref1,

--- a/parser.go
+++ b/parser.go
@@ -66,7 +66,8 @@ func parseInterface(ctx *parseFileContext, name string, spec *ast.InterfaceType,
 	for _, m := range spec.Methods.List {
 		funcType, ok := m.Type.(*ast.FuncType)
 		if !ok {
-			return nil, errors.Wrapf(ErrUnexpectedExpressionType, "*FuncType expected but %T found", m.Type)
+			pos := ctx.FSet.Position(spec.Pos())
+			return nil, errors.Wrapf(ErrUnexpectedExpressionType, "*FuncType expected but %T found while parsing %s (%s)", m.Type, name, pos.String())
 		}
 		name := ""
 		if len(m.Names) > 0 {

--- a/struct.go
+++ b/struct.go
@@ -2,18 +2,14 @@ package myasthurts
 
 type Struct struct {
 	baseType
-	Doc        Doc
-	Fields     []*Field
-	Interfaces []*Interface
+	Doc    Doc
+	Fields []*Field
 }
 
 // NewStruct return new pointer Struct
 func NewStruct(pkg *Package, name string) *Struct {
 	srct := &Struct{
-		baseType: baseType{
-			pkg:  pkg,
-			name: name,
-		},
+		baseType: *NewBaseType(pkg, name),
 	}
 	return srct
 }
@@ -26,4 +22,21 @@ func (s *Struct) Package() *Package {
 // Name return name of Struct
 func (s *Struct) Name() string {
 	return s.name
+}
+
+// Implements checks if this struct implements a given interface.
+//
+// This method uses the `MethodDescriptor.Compatible` to check if all interface
+// methods have are implemented on the struct.
+func (s *Struct) Implements(i *Interface) bool {
+	for _, m := range i.Methods() {
+		method, ok := s.methodsMap[m.Descriptor.Name()]
+		if !ok {
+			return false
+		}
+		if !method.Descriptor.Compatible(m.Descriptor) {
+			return false
+		}
+	}
+	return true
 }

--- a/struct.go
+++ b/struct.go
@@ -28,6 +28,8 @@ func (s *Struct) Name() string {
 //
 // This method uses the `MethodDescriptor.Compatible` to check if all interface
 // methods have are implemented on the struct.
+//
+// TODO(jota): Take into consideration Interface composing...
 func (s *Struct) Implements(i *Interface) bool {
 	for _, m := range i.Methods() {
 		method, ok := s.methodsMap[m.Descriptor.Name()]

--- a/struct.go
+++ b/struct.go
@@ -1,0 +1,29 @@
+package myasthurts
+
+type Struct struct {
+	baseType
+	Doc        Doc
+	Fields     []*Field
+	Interfaces []*Interface
+}
+
+// NewStruct return new pointer Struct
+func NewStruct(pkg *Package, name string) *Struct {
+	srct := &Struct{
+		baseType: baseType{
+			pkg:  pkg,
+			name: name,
+		},
+	}
+	return srct
+}
+
+// Package return pointer package of Struct
+func (s *Struct) Package() *Package {
+	return s.pkg
+}
+
+// Name return name of Struct
+func (s *Struct) Name() string {
+	return s.name
+}

--- a/struct_test.go
+++ b/struct_test.go
@@ -1,0 +1,62 @@
+package myasthurts
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Struct", func() {
+	Describe("Implements", func() {
+		It("should find struct implements an interface", func() {
+			env, err := NewEnvironment()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(env.parseFile(newDataPackageContext(env), "data/interface.go")).To(Succeed())
+
+			pkg, ok := env.PackageByImportPath("data")
+			Expect(ok).To(BeTrue())
+
+			s, ok := pkg.StructByName("InterfaceUser")
+			Expect(ok).To(BeTrue())
+			Expect(s.methodsMap).To(HaveKey("Name"))
+			Expect(s.methodsMap).To(HaveKey("SetName"))
+
+			Expect(pkg.Interfaces).To(HaveLen(3))
+			Expect(pkg.Interfaces[0].Name()).To(Equal("HasName"))
+			Expect(pkg.Interfaces[1].Name()).To(Equal("HasAge"))
+			Expect(pkg.Interfaces[2].Name()).To(Equal("HasNameWrong"))
+
+			Expect(s.Implements(pkg.Interfaces[0])).To(BeTrue())
+		})
+
+		It("should not recognize the interface with missing methods", func() {
+			env, err := NewEnvironment()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(env.parseFile(newDataPackageContext(env), "data/interface.go")).To(Succeed())
+
+			pkg, ok := env.PackageByImportPath("data")
+			Expect(ok).To(BeTrue())
+
+			s, ok := pkg.StructByName("InterfaceUser")
+			Expect(ok).To(BeTrue())
+
+			Expect(s.Implements(pkg.Interfaces[1])).To(BeFalse())
+		})
+
+		It("should not recognize the interface with incompatible methods", func() {
+			env, err := NewEnvironment()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(env.parseFile(newDataPackageContext(env), "data/interface.go")).To(Succeed())
+
+			pkg, ok := env.PackageByImportPath("data")
+			Expect(ok).To(BeTrue())
+
+			s, ok := pkg.StructByName("InterfaceUser")
+			Expect(ok).To(BeTrue())
+
+			Expect(s.Implements(pkg.Interfaces[2])).To(BeFalse())
+		})
+	})
+})


### PR DESCRIPTION
### :sparkles: Enhancements

* Implement parsing interfaces;
* Implement a method for checking if a `Struct` implements an `Interface`;

### :recycle: Refactoring

* Update how some `Struct` methods are parsed;
* Create a map for caching methods by name on the `baseType`;

### :bug: Bugs

* Function results were not being parsed, neither tested;